### PR TITLE
chore: add markdown-preview-github-styles extension

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,6 +6,7 @@
         "vscode": {
             "settings": {},
             "extensions": [
+                "bierner.markdown-preview-github-styles",
                 "vue.volar"
             ]
         }


### PR DESCRIPTION
## Overview
Add markdown preview extension 

## Description
for GitHub docs

## Linked issue
<!-- For example, "resolves #123" -->
