### PR TITLE
chore: fix ERR_CONTENT_LENGTH_MISMATCH in devcontainer

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "scripts": {
     "build": "nuxt build",
-    "dev": "nuxt dev",
+    "dev": "nuxt dev --no-fork",
     "generate": "nuxt generate",
     "preview": "nuxt preview",
     "postinstall": "nuxt prepare",


### PR DESCRIPTION
## Overview
fix bug when you run `npm run dev` in devcontainer on vscode

## Description
fix these error
```
GET http://127.0.0.1:3002/_nuxt/@fs/workspaces/yumemi-frontend-coding-test/node_modules/h3/dist/index.mjs?v=a1f5c182 net::ERR_CONTENT_LENGTH_MISMATCH 200 (OK)Understand this error
runtime-dom.esm-bundler.js:6 
```
```        
GET http://127.0.0.1:3002/_nuxt/@fs/workspaces/yumemi-frontend-coding-test/node_modules/@vue/runtime-core/dist/runtime-core.esm-bundler.js?v=a1f5c182 net::ERR_CONTENT_LENGTH_MISMATCH 200 (OK)
```

reference: [https://github.com/nuxt/cli/issues/181](https://github.com/nuxt/cli/issues/181)

## Linked issue

<!-- For example, "resolves #123" -->
